### PR TITLE
Remove outer variable shadowing within the block

### DIFF
--- a/lib/env_bang/classes.rb
+++ b/lib/env_bang/classes.rb
@@ -17,7 +17,7 @@ class ENV_BANG
 
       def Array(value, options)
         item_options = options.merge(class: options.fetch(:of, default_class))
-        value.split(',').map { |value| cast(value.strip, item_options) }
+        value.split(',').map { |v| cast(v.strip, item_options) }
       end
 
       def Symbol(value, options)


### PR DESCRIPTION
Because the `value` variable exists and is manipulated both inside and outside of the `map` block, it's both confusing and causes Ruby warnings.  This is a simple change to rename the inner variable to `v` from `value`.
