### PR TITLE
Add basic support for hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ ENV!.config do
   use :MAIL_DELIVERY_METHOD, class: Symbol, default: :smtp
   use :DEFAULT_FRACTION,     class: Float
   use :ENABLE_SOUNDTRACK,    class: :boolean
+  use :PUPPETMASTERS,        class: Hash
 end
 ```
 
@@ -117,6 +118,14 @@ of a specific type of value, use the `:of` option:
 ```ruby
 ENV!.config do
   use :YEARS_OF_INTEREST, class: Array, of: Integer
+end
+```
+
+Hashes are split on commas (',') and key:value pairs are delimited by colon (':'). To get hashes of a specific type of value, use the `:of` option, and to use a different type for keys (default is `Symbol`), use the `:keys` option:
+
+```ruby
+ENV!.config do
+  use :BIRTHDAYS, class: Hash, of: Integer, keys: String
 end
 ```
 

--- a/lib/env_bang/classes.rb
+++ b/lib/env_bang/classes.rb
@@ -20,6 +20,17 @@ class ENV_BANG
         value.split(',').map { |v| cast(v.strip, item_options) }
       end
 
+      def Hash(value, options)
+        key_options   = options.merge(class: options.fetch(:keys, Symbol))
+        value_options = options.merge(class: options.fetch(:of, default_class))
+        {}.tap do |h|
+          value.split(',').each do |pair|
+            key, value = pair.split(':')
+            h[cast(key.strip, key_options)] = cast(value.strip, value_options)
+          end
+        end
+      end
+
       def Symbol(value, options)
         value.to_sym
       end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -99,6 +99,27 @@ describe ENV_BANG do
       end
     end
 
+    it "Casts Hashes" do
+      ENV['HASH'] = 'one: two, three: four'
+      ENV!.use 'HASH', class: Hash
+
+      ENV!['HASH'].must_equal({one: 'two', three: 'four'})
+    end
+
+    it 'Casts Hashes of Integers' do
+      ENV['INT_HASH'] = 'one: 111, two: 222'
+      ENV!.use 'INT_HASH', class: Hash, of: Integer
+
+      ENV!['INT_HASH'].must_equal({one: 111, two: 222})
+    end
+
+    it 'Casts Hashes with String keys' do
+      ENV['STRKEY_HASH'] = 'one: two, three: four'
+      ENV!.use 'STRKEY_HASH', class: Hash, keys: String
+
+      ENV!['STRKEY_HASH'].must_equal({'one' => 'two', 'three' => 'four'})
+    end
+
     it "Casts true" do
       ENV['TRUE'] = truthy_values.sample
       ENV!.use 'TRUE', class: :boolean


### PR DESCRIPTION
This pull request adds basic support for hashes, in the form:

`SOME_HASH=one:foo,two:bar`

The type of the values is set with `:of` and the type of the keys with `:keys` (defaults to `Symbol`).