### PR TITLE
Make error output more readable and helpful

### DIFF
--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -21,7 +21,9 @@ class ENV_BANG
     end
 
     def raise_formatted_error(var, description)
-      raise KeyError.new Formatter.formatted_error(var, description)
+      e = KeyError.new(Formatter.formatted_error(var, description))
+      e.set_backtrace(caller[3..-1])
+      raise e
     end
 
     def vars

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -10,7 +10,7 @@ class ENV_BANG
 
     def use(var, *args)
       var = var.to_s
-      description = args.first.is_a?(String) && args.shift
+      description = args.first.is_a?(String) ? args.shift : nil
       options = args.last.is_a?(Hash) ? args.pop : {}
 
       unless ENV.has_key?(var)
@@ -20,7 +20,7 @@ class ENV_BANG
       vars[var] = options
     end
 
-    def raise_formatted_error(var, description) 
+    def raise_formatted_error(var, description)
       raise KeyError.new Formatter.formatted_error(var, description)
     end
 

--- a/lib/env_bang/formatter.rb
+++ b/lib/env_bang/formatter.rb
@@ -2,11 +2,11 @@ class ENV_BANG
   module Formatter
     class << self
       def formatted_error(var, description)
-        indent 4, <<-EOS
+        indent(4, "
 
-  Missing required environment variable: #{var}#{ description and "\n" <<
-  unindent(description) }
-        EOS
+Missing required environment variable: #{var}#{description and "\n" <<
+unindent(description) }
+        ")
       end
 
       def unindent(string)
@@ -15,7 +15,7 @@ class ENV_BANG
       end
 
       def indent(width, string)
-        string.gsub "\n", "\n#{' ' * width}"
+        string.gsub("\n", "\n#{' ' * width}")
       end
     end
   end


### PR DESCRIPTION
* Clean up some broken formatting
* Change the backtrace of raised error so it prints the location where the `ENV!.use` defined the required variable.