### PR TITLE
Check type coercion during config

### DIFF
--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -18,6 +18,9 @@ class ENV_BANG
       end
 
       vars[var] = options
+
+      # Make sure reading/coercing the value works. If it's going to raise an error, raise it now.
+      self[var]
     end
 
     def raise_formatted_error(var, description)

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -21,6 +21,17 @@ describe ENV_BANG do
     }.must_raise KeyError
   end
 
+  it "Raises exception immediately if value is invalid for the required type" do
+    proc {
+      ENV['NOT_A_DATE'] = '2017-02-30'
+      ENV!.use 'NOT_A_DATE', class: Date
+    }.must_raise ArgumentError
+
+    proc {
+      ENV!.use 'NOT_A_DATE_DEFAULT', class: Date, default: '2017-02-31'
+    }.must_raise ArgumentError
+  end
+
   it "Uses provided default value if ENV var not already present" do
     ENV.delete('WASNT_PRESENT')
 


### PR DESCRIPTION
If the value can't be coerced successfully, we want an exception during
boot/config, not later.