### PR TITLE
Support Regexp & Range to round out built-in types

### DIFF
--- a/lib/env_bang/classes.rb
+++ b/lib/env_bang/classes.rb
@@ -84,6 +84,10 @@ class ENV_BANG
         require 'time'
         Time.parse(value)
       end
+
+      def Regexp(value, options)
+        Regexp.new(value)
+      end
     end
   end
 end

--- a/lib/env_bang/classes.rb
+++ b/lib/env_bang/classes.rb
@@ -85,6 +85,28 @@ class ENV_BANG
         Time.parse(value)
       end
 
+      def Range(value, options = {})
+        beginning, ending = value.split('...')
+        if beginning && ending
+          options[:exclusive] = true unless options.has_key?(:exclusive)
+        else
+          beginning, ending = value.split('..')
+        end
+        unless beginning && ending
+          raise ArgumentError.new("Range '#{value}' cannot be parsed as a range. Must be in the form <start>..<end> or <start>...<end>")
+        end
+
+        options[:of] ||= Integer
+        beginning = cast(beginning, class: options[:of])
+        ending    = cast(ending, class: options[:of])
+
+        if options[:exclusive]
+          beginning...ending
+        else
+          beginning..ending
+        end
+      end
+
       def Regexp(value, options)
         Regexp.new(value)
       end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -199,6 +199,40 @@ describe ENV_BANG do
       ENV!['A_REGEX'].must_equal(/^(this|is|a|[^tes.*\|]t.\.\*\/\\)$/)
     end
 
+    it "casts inclusive Ranges of Integers by default" do
+      ENV['A_RANGE'] = '1..100'
+      ENV!.use 'A_RANGE', class: Range
+
+      ENV!['A_RANGE'].class.must_equal Range
+      ENV!['A_RANGE'].must_equal 1..100
+    end
+
+    it "casts exclusive Ranges as directed" do
+      ENV['EXCLUSIVE_RANGE'] = '1..100'
+      ENV!.use 'EXCLUSIVE_RANGE', class: Range, exclusive: true
+
+      ENV!['EXCLUSIVE_RANGE'].must_equal 1...100
+
+      ENV['ANOTHER_EXCLUSIVE_RANGE'] = '1...100'
+      ENV!.use 'ANOTHER_EXCLUSIVE_RANGE', class: Range, exclusive: true
+
+      ENV!['ANOTHER_EXCLUSIVE_RANGE'].must_equal 1...100
+    end
+
+    it "casts Ranges of floats" do
+      ENV['FLOAT_RANGE'] = '1.5..100.7'
+      ENV!.use 'FLOAT_RANGE', class: Range, of: Float
+
+      ENV!['FLOAT_RANGE'].must_equal 1.5..100.7
+    end
+
+    it "casts Ranges of strings" do
+      ENV['FLOAT_RANGE'] = 'az..za'
+      ENV!.use 'FLOAT_RANGE', class: Range, of: String
+
+      ENV!['FLOAT_RANGE'].must_equal 'az'..'za'
+    end
+
     it "allows default class to be overridden" do
       ENV!.default_class.must_equal :StringUnlessFalsey
       ENV!.config { default_class String }

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -190,6 +190,15 @@ describe ENV_BANG do
       ENV!['A_TIME'].must_equal Time.new(2005, 5, 5, 17, 5)
     end
 
+    it "casts Regexps" do
+      # Escaping backslashes is not without its pitfalls. Developer beware.
+      ENV['A_REGEX'] = '^(this|is|a|[^tes.*\|]t.\.\*/\\\)$'
+      ENV!.use 'A_REGEX', class: Regexp
+
+      ENV!['A_REGEX'].class.must_equal Regexp
+      ENV!['A_REGEX'].must_equal(/^(this|is|a|[^tes.*\|]t.\.\*\/\\)$/)
+    end
+
     it "allows default class to be overridden" do
       ENV!.default_class.must_equal :StringUnlessFalsey
       ENV!.config { default_class String }


### PR DESCRIPTION
If you're app needs a regex from an environment variable, you might as well eagerly coerce it at boot time in a standardized way.