### PR TITLE
Remove passing-through access to raw ENV

### DIFF
--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -117,11 +117,11 @@ class ENV_BANG
       to_h.key(value)
     end
 
-    #def key?(key)
-    #  vars.key?(key)
-    #end
+    def key?(key)
+      vars.key?(key)
+    end
 
-    #alias has_key? key?
+    alias has_key? key?
 
     def length
       to_h.length
@@ -133,21 +133,21 @@ class ENV_BANG
 
     alias size length
 
-    #def slice(*keys)
-    #  to_h.slice(*keys)
-    #end
+    def slice(*keys)
+      to_h.slice(*keys)
+    end
 
     alias to_hash to_h
 
-    #def value?(value)
-    #  vars.value?(value)
-    #end
+    def value?(value)
+      values.include?(value)
+    end
 
-    #alias has_value? value?
+    alias has_value? value?
 
-    #def values_at(*keys)
-    #  to_h.values_at(*keys)
-    #end
+    def values_at(*keys)
+      to_h.values_at(*keys)
+    end
 
     ##########################################################
     # Implement Hash-like write methods                      #

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -84,10 +84,8 @@ class ENV_BANG
       (requested_keys & keys).map { |k| [k, self[k]] }.to_h
     end
 
-    if {}.respond_to?(:except)
-      def except(*exceptions)
-        slice(*(keys - exceptions))
-      end
+    def except(*exceptions)
+      slice(*(keys - exceptions))
     end
 
     def value?(value)

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -76,6 +76,128 @@ class ENV_BANG
     def each(&block)
       to_h.each(&block)
     end
+
+    ####################################
+    # Implement Hash-like read methods #
+    ####################################
+
+    def assoc(key)
+      to_h.assoc(key)
+    end
+
+    #def each_key(*key, &block)
+    #  to_h.each_key(*key, &block)
+    #end
+
+    #def each_pair(*args, &block)
+    #  to_h.each_pair(*args, &block)
+    #end
+
+    #def each_value(*args, &block)
+    #  to_h.each_value(*args, &block)
+    #end
+
+    #def empty?
+    #  to_h.empty?
+    #end
+
+    #def except(*keys)
+    #  to_h.except(*keys)
+    #end
+
+    #def fetch(key, *args, &block)
+    #  to_h.fetch(key, *args, &block)
+    #end
+
+    def invert
+      to_h.invert
+    end
+
+    #def key(value)
+    #  to_h.key(value)
+    #end
+
+    #def key?(key)
+    #  vars.key?(key)
+    #end
+
+    #alias has_key? key?
+
+    def length
+      to_h.length
+    end
+
+    def rassoc(value)
+      to_h.rassoc(value)
+    end
+
+    alias size length
+
+    #def slice(*keys)
+    #  to_h.slice(*keys)
+    #end
+
+    alias to_hash to_h
+
+    #def value?(value)
+    #  vars.value?(value)
+    #end
+
+    #alias has_value? value?
+
+    #def values_at(*keys)
+    #  to_h.values_at(*keys)
+    #end
+
+    ##########################################################
+    # Implement Hash-like write methods                      #
+    # These must dump to the underlying ENV data structure--
+    # if the key is allowed by configuration
+    #
+    # TODO: Test & implement the following
+    #
+    # Note write capability will require each class adapter to be a
+    # serializer with load & dump methods.
+    ##########################################################
+
+    #def replace
+    #end
+
+    #def clear
+    #end
+
+    #def shift
+    #end
+
+    #def select!
+    #end
+
+    #def filter!
+    #end
+
+    #def keep_if
+    #end
+
+    #def delete_if
+    #end
+
+    #def reject!
+    #end
+
+    #def delete
+    #end
+
+    #def rehash
+    #end
+
+    #def store
+    #end
+
+    #def update
+    #end
+
+    #def merge!
+    #end
   end
 end
 

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -1,9 +1,11 @@
 require "env_bang/version"
 require "env_bang/classes"
 require "env_bang/formatter"
+require "forwardable"
 
 class ENV_BANG
   class << self
+    extend Forwardable
     include Enumerable
 
     def config(&block)
@@ -62,39 +64,24 @@ class ENV_BANG
       end
     end
 
-    ############################
-    # Implement Enumerable API #
-    ############################
     def to_h
       keys.map { |k| [k, self[k]] }.to_h
     end
 
-    def each(&block)
-      to_h.each(&block)
-    end
+    alias to_hash to_h
 
     ####################################
     # Implement Hash-like read methods #
     ####################################
 
-    def assoc(key)
-      to_h.assoc(key)
-    end
+    def_delegators :to_h,
+      :each, :assoc, :each_pair, :each_value, :empty?, :fetch,
+      :invert, :key, :rassoc, :values_at
 
-    def each_key(*key, &block)
-      to_h.each_key(*key, &block)
-    end
+    def_delegators :vars, :each_key, :has_key?, :key?, :length, :size
 
-    def each_pair(*args, &block)
-      to_h.each_pair(*args, &block)
-    end
-
-    def each_value(*args, &block)
-      to_h.each_value(*args, &block)
-    end
-
-    def empty?
-      to_h.empty?
+    def slice(*requested_keys)
+      (requested_keys & keys).map { |k| [k, self[k]] }.to_h
     end
 
     if {}.respond_to?(:except)
@@ -103,49 +90,11 @@ class ENV_BANG
       end
     end
 
-    def fetch(key, *args, &block)
-      to_h.fetch(key, *args, &block)
-    end
-
-    def invert
-      to_h.invert
-    end
-
-    def key(value)
-      to_h.key(value)
-    end
-
-    def key?(key)
-      vars.key?(key)
-    end
-
-    alias has_key? key?
-
-    def length
-      vars.length
-    end
-
-    def rassoc(value)
-      to_h.rassoc(value)
-    end
-
-    alias size length
-
-    def slice(*requested_keys)
-      (requested_keys & keys).map { |k| [k, self[k]] }.to_h
-    end
-
-    alias to_hash to_h
-
     def value?(value)
       values.include?(value)
     end
 
     alias has_value? value?
-
-    def values_at(*keys)
-      to_h.values_at(*keys)
-    end
   end
 end
 

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -4,6 +4,8 @@ require "env_bang/formatter"
 
 class ENV_BANG
   class << self
+    include Enumerable
+
     def config(&block)
       instance_eval(&block)
     end
@@ -69,6 +71,10 @@ class ENV_BANG
     ############################
     def to_h
       keys.map { |k| [k, self[k]] }.to_h
+    end
+
+    def each(&block)
+      to_h.each(&block)
     end
   end
 end

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -146,56 +146,6 @@ class ENV_BANG
     def values_at(*keys)
       to_h.values_at(*keys)
     end
-
-    ##########################################################
-    # Implement Hash-like write methods                      #
-    # These must dump to the underlying ENV data structure--
-    # if the key is allowed by configuration
-    #
-    # TODO: Test & implement the following
-    #
-    # Note write capability will require each class adapter to be a
-    # serializer with load & dump methods.
-    ##########################################################
-
-    #def replace
-    #end
-
-    #def clear
-    #end
-
-    #def shift
-    #end
-
-    #def select!
-    #end
-
-    #def filter!
-    #end
-
-    #def keep_if
-    #end
-
-    #def delete_if
-    #end
-
-    #def reject!
-    #end
-
-    #def delete
-    #end
-
-    #def rehash
-    #end
-
-    #def store
-    #end
-
-    #def update
-    #end
-
-    #def merge!
-    #end
   end
 end
 

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -97,8 +97,10 @@ class ENV_BANG
       to_h.empty?
     end
 
-    def except(*keys)
-      to_h.except(*keys)
+    if {}.respond_to?(:except)
+      def except(*keys)
+        to_h.except(*keys)
+      end
     end
 
     def fetch(key, *args, &block)

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -63,6 +63,13 @@ class ENV_BANG
         Classes.default_class
       end
     end
+
+    ############################
+    # Implement Enumerable API #
+    ############################
+    def to_h
+      keys.map { |k| [k, self[k]] }.to_h
+    end
   end
 end
 

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -50,10 +50,6 @@ class ENV_BANG
       Classes.cast ENV[var], vars[var]
     end
 
-    def method_missing(method, *args, &block)
-      ENV.send(method, *args, &block)
-    end
-
     def add_class(klass, &block)
       Classes.send :define_singleton_method, klass.to_s, &block
     end

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -105,9 +105,9 @@ class ENV_BANG
     #  to_h.except(*keys)
     #end
 
-    #def fetch(key, *args, &block)
-    #  to_h.fetch(key, *args, &block)
-    #end
+    def fetch(key, *args, &block)
+      to_h.fetch(key, *args, &block)
+    end
 
     def invert
       to_h.invert

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -85,25 +85,25 @@ class ENV_BANG
       to_h.assoc(key)
     end
 
-    #def each_key(*key, &block)
-    #  to_h.each_key(*key, &block)
-    #end
+    def each_key(*key, &block)
+      to_h.each_key(*key, &block)
+    end
 
-    #def each_pair(*args, &block)
-    #  to_h.each_pair(*args, &block)
-    #end
+    def each_pair(*args, &block)
+      to_h.each_pair(*args, &block)
+    end
 
-    #def each_value(*args, &block)
-    #  to_h.each_value(*args, &block)
-    #end
+    def each_value(*args, &block)
+      to_h.each_value(*args, &block)
+    end
 
-    #def empty?
-    #  to_h.empty?
-    #end
+    def empty?
+      to_h.empty?
+    end
 
-    #def except(*keys)
-    #  to_h.except(*keys)
-    #end
+    def except(*keys)
+      to_h.except(*keys)
+    end
 
     def fetch(key, *args, &block)
       to_h.fetch(key, *args, &block)
@@ -113,9 +113,9 @@ class ENV_BANG
       to_h.invert
     end
 
-    #def key(value)
-    #  to_h.key(value)
-    #end
+    def key(value)
+      to_h.key(value)
+    end
 
     #def key?(key)
     #  vars.key?(key)

--- a/lib/env_bang.rb
+++ b/lib/env_bang.rb
@@ -98,8 +98,8 @@ class ENV_BANG
     end
 
     if {}.respond_to?(:except)
-      def except(*keys)
-        to_h.except(*keys)
+      def except(*exceptions)
+        slice(*(keys - exceptions))
       end
     end
 
@@ -122,7 +122,7 @@ class ENV_BANG
     alias has_key? key?
 
     def length
-      to_h.length
+      vars.length
     end
 
     def rassoc(value)
@@ -131,8 +131,8 @@ class ENV_BANG
 
     alias size length
 
-    def slice(*keys)
-      to_h.slice(*keys)
+    def slice(*requested_keys)
+      (requested_keys & keys).map { |k| [k, self[k]] }.to_h
     end
 
     alias to_hash to_h

--- a/lib/env_bang/version.rb
+++ b/lib/env_bang/version.rb
@@ -1,3 +1,3 @@
 class ENV_BANG
-  VERSION = "1.0.0"
+  VERSION = "2.0.0.alpha.1"
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -470,10 +470,14 @@ describe ENV_BANG do
     end
 
     it "implements .except correctly" do
-      ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
-        'ONE'      => 1,
-        'A'        => 'A',
-      })
+      if {}.respond_to?(:except)
+        ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
+          'ONE'      => 1,
+          'A'        => 'A',
+        })
+      else
+        ENV!.respond_to?(:except).must_equal false
+      end
     end
 
     it "implements .fetch correctly" do

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -438,6 +438,15 @@ describe ENV_BANG do
       ENV!.rassoc(1).must_equal ['ONE', 1]
     end
 
+    it "implements .fetch correctly" do
+      ENV!.fetch('ONE').must_equal 1
+      proc {
+        ENV!.fetch('TWO')
+      }.must_raise KeyError
+      ENV!.fetch('TWO', 2).must_equal 2
+      ENV!.fetch('TWO') { 22 }.must_equal 22
+    end
+
     it "implements .invert correctly" do
       ENV!.invert.must_equal({
         1 => 'ONE',

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -366,4 +366,29 @@ describe ENV_BANG do
       UNINDENTED
     end
   end
+
+  describe "Enumerable methods" do
+    before do
+      ENV['ONE'] = '1'
+      ENV['A'] = 'A'
+      ENV['INT_HASH'] = 'one: 1, two: 2'
+      ENV['FLOAT'] = '1.234'
+
+      ENV!.config do
+        use 'ONE', class: Integer
+        use 'A', class: String
+        use 'INT_HASH', class: Hash, of: Integer
+        use 'FLOAT', class: Float
+      end
+    end
+
+    it "converts keys and parsed values to a Hash" do
+      ENV!.to_h.must_equal({
+        'ONE'      => 1,
+        'A'        => 'A',
+        'INT_HASH' => { one: 1, two: 2 },
+        'FLOAT'    => 1.234,
+      })
+    end
+  end
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -470,14 +470,10 @@ describe ENV_BANG do
     end
 
     it "implements .except correctly" do
-      if {}.respond_to?(:except)
-        _(ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal({
-          'ONE'      => 1,
-          'A'        => 'A',
-        })
-      else
-        _(ENV!.respond_to?(:except)).must_equal false
-      end
+      _(ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal({
+        'ONE'      => 1,
+        'A'        => 'A',
+      })
     end
 
     it "implements .fetch correctly" do

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -399,7 +399,7 @@ describe ENV_BANG do
 
     it "returns an Array representation of the hash too" do
       _(ENV!.to_a).must_equal [
-        ['ONE' , 1],
+        ['ONE', 1],
         ['A', 'A'],
         ['INT_HASH', { one: 1, two: 2 }],
         ['FLOAT', 1.234],
@@ -408,7 +408,7 @@ describe ENV_BANG do
 
     it "implements other Enumerable methods too" do
       _(ENV!.each.to_a).must_equal [
-        ['ONE' , 1],
+        ['ONE', 1],
         ['A', 'A'],
         ['INT_HASH', { one: 1, two: 2 }],
         ['FLOAT', 1.234],
@@ -471,8 +471,8 @@ describe ENV_BANG do
 
     it "implements .except correctly" do
       _(ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal({
-        'ONE'      => 1,
-        'A'        => 'A',
+        'ONE' => 1,
+        'A'   => 'A',
       })
     end
 

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -417,4 +417,43 @@ describe ENV_BANG do
       ENV!.to_enum.to_a.must_equal ENV!.to_a
     end
   end
+
+  describe "Hash-like read methods" do
+    before do
+      ENV['ONE'] = '1'
+      ENV['A'] = 'A'
+      ENV['INT_HASH'] = 'one: 1, two: 2'
+      ENV['FLOAT'] = '1.234'
+
+      ENV!.config do
+        use 'ONE', class: Integer
+        use 'A', class: String
+        use 'INT_HASH', class: Hash, of: Integer
+        use 'FLOAT', class: Float
+      end
+    end
+
+    it "implements .assoc and .rassoc correctly" do
+      ENV!.assoc('ONE').must_equal ['ONE', 1]
+      ENV!.rassoc(1).must_equal ['ONE', 1]
+    end
+
+    it "implements .invert correctly" do
+      ENV!.invert.must_equal({
+        1 => 'ONE',
+        'A' => 'A',
+        { one: 1, two: 2 } => 'INT_HASH',
+        1.234 => 'FLOAT',
+      })
+    end
+
+    it "implements .length correctly" do
+      ENV!.length.must_equal 4
+      ENV!.size.must_equal 4
+    end
+
+    it "implements .to_hash correctly" do
+      ENV!.to_hash.must_equal ENV!.to_h
+    end
+  end
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -498,13 +498,41 @@ describe ENV_BANG do
       ENV!.key(1).must_equal 'ONE'
     end
 
+    it "implements .key?/.has_key? correctly" do
+      ENV!.key?('ONE').must_equal true
+      ENV!.has_key?('ONE').must_equal true
+
+      ENV!.key?('TWO').must_equal false
+      ENV!.has_key?('TWO').must_equal false
+    end
+
     it "implements .length correctly" do
       ENV!.length.must_equal 4
       ENV!.size.must_equal 4
     end
 
+    it "implements .slice correctly" do
+      ENV!.slice('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
+        'INT_HASH' => { one: 1, two: 2 },
+        'FLOAT'    => 1.234,
+      })
+    end
+
     it "implements .to_hash correctly" do
       ENV!.to_hash.must_equal ENV!.to_h
+    end
+
+    it "implements .value?/has_value? correctly" do
+      ENV!.value?(1).must_equal true
+      ENV!.value?(2).must_equal false
+      ENV!.has_value?(1).must_equal true
+      ENV!.has_value?(2).must_equal false
+    end
+
+    it "implements .values_at correctly" do
+      ENV!.values_at('INT_HASH', 'FLOAT', 'NOTATHING').must_equal [
+        { one: 1, two: 2 }, 1.234, nil
+      ]
     end
   end
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -438,6 +438,44 @@ describe ENV_BANG do
       ENV!.rassoc(1).must_equal ['ONE', 1]
     end
 
+    it "implements .each_key correctly" do
+      ENV!.each_key.to_a.must_equal(%w[ONE A INT_HASH FLOAT])
+      keys = []
+      ENV!.each_key do |key|
+        keys << key
+      end
+      keys.must_equal(%w[ONE A INT_HASH FLOAT])
+    end
+
+    it "implements .each_pair correctly" do
+      ENV!.each_pair.to_a.must_equal(ENV!.to_a)
+      keys = []
+      ENV!.each_pair do |key|
+        keys << key
+      end
+      keys.must_equal(ENV!.to_a)
+    end
+
+    it "implements .each_value correctly" do
+      ENV!.each_value.to_a.must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
+      keys = []
+      ENV!.each_value do |key|
+        keys << key
+      end
+      keys.must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
+    end
+
+    it "implements .empty? correctly" do
+      ENV!.empty?.must_equal(false)
+    end
+
+    it "implements .except correctly" do
+      ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
+        'ONE'      => 1,
+        'A'        => 'A',
+      })
+    end
+
     it "implements .fetch correctly" do
       ENV!.fetch('ONE').must_equal 1
       proc {
@@ -454,6 +492,10 @@ describe ENV_BANG do
         { one: 1, two: 2 } => 'INT_HASH',
         1.234 => 'FLOAT',
       })
+    end
+
+    it "implements .key correctly" do
+      ENV!.key(1).must_equal 'ONE'
     end
 
     it "implements .length correctly" do

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -390,5 +390,11 @@ describe ENV_BANG do
         'FLOAT'    => 1.234,
       })
     end
+
+    it "Doesn't allow write access via the hash (It's not a reference to internal values)" do
+      h = ENV!.to_h
+      h['A'] = 'changed'
+      ENV!['A'].must_equal 'A'
+    end
   end
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -396,5 +396,25 @@ describe ENV_BANG do
       h['A'] = 'changed'
       ENV!['A'].must_equal 'A'
     end
+
+    it "returns an Array representation of the hash too" do
+      ENV!.to_a.must_equal [
+        ['ONE' , 1],
+        ['A', 'A'],
+        ['INT_HASH', { one: 1, two: 2 }],
+        ['FLOAT', 1.234],
+      ]
+    end
+
+    it "implements other Enumerable methods too" do
+      ENV!.each.to_a.must_equal [
+        ['ONE' , 1],
+        ['A', 'A'],
+        ['INT_HASH', { one: 1, two: 2 }],
+        ['FLOAT', 1.234],
+      ]
+
+      ENV!.to_enum.to_a.must_equal ENV!.to_a
+    end
   end
 end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -383,7 +383,7 @@ describe ENV_BANG do
     end
 
     it "converts keys and parsed values to a Hash" do
-      ENV!.to_h.must_equal({
+      _(ENV!.to_h).must_equal({
         'ONE'      => 1,
         'A'        => 'A',
         'INT_HASH' => { one: 1, two: 2 },
@@ -394,11 +394,11 @@ describe ENV_BANG do
     it "Doesn't allow write access via the hash (It's not a reference to internal values)" do
       h = ENV!.to_h
       h['A'] = 'changed'
-      ENV!['A'].must_equal 'A'
+      _(ENV!['A']).must_equal 'A'
     end
 
     it "returns an Array representation of the hash too" do
-      ENV!.to_a.must_equal [
+      _(ENV!.to_a).must_equal [
         ['ONE' , 1],
         ['A', 'A'],
         ['INT_HASH', { one: 1, two: 2 }],
@@ -407,14 +407,14 @@ describe ENV_BANG do
     end
 
     it "implements other Enumerable methods too" do
-      ENV!.each.to_a.must_equal [
+      _(ENV!.each.to_a).must_equal [
         ['ONE' , 1],
         ['A', 'A'],
         ['INT_HASH', { one: 1, two: 2 }],
         ['FLOAT', 1.234],
       ]
 
-      ENV!.to_enum.to_a.must_equal ENV!.to_a
+      _(ENV!.to_enum.to_a).must_equal ENV!.to_a
     end
   end
 
@@ -434,63 +434,63 @@ describe ENV_BANG do
     end
 
     it "implements .assoc and .rassoc correctly" do
-      ENV!.assoc('ONE').must_equal ['ONE', 1]
-      ENV!.rassoc(1).must_equal ['ONE', 1]
+      _(ENV!.assoc('ONE')).must_equal ['ONE', 1]
+      _(ENV!.rassoc(1)).must_equal ['ONE', 1]
     end
 
     it "implements .each_key correctly" do
-      ENV!.each_key.to_a.must_equal(%w[ONE A INT_HASH FLOAT])
+      _(ENV!.each_key.to_a).must_equal(%w[ONE A INT_HASH FLOAT])
       keys = []
       ENV!.each_key do |key|
         keys << key
       end
-      keys.must_equal(%w[ONE A INT_HASH FLOAT])
+      _(keys).must_equal(%w[ONE A INT_HASH FLOAT])
     end
 
     it "implements .each_pair correctly" do
-      ENV!.each_pair.to_a.must_equal(ENV!.to_a)
+      _(ENV!.each_pair.to_a).must_equal(ENV!.to_a)
       keys = []
       ENV!.each_pair do |key|
         keys << key
       end
-      keys.must_equal(ENV!.to_a)
+      _(keys).must_equal(ENV!.to_a)
     end
 
     it "implements .each_value correctly" do
-      ENV!.each_value.to_a.must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
+      _(ENV!.each_value.to_a).must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
       keys = []
       ENV!.each_value do |key|
         keys << key
       end
-      keys.must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
+      _(keys).must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
     end
 
     it "implements .empty? correctly" do
-      ENV!.empty?.must_equal(false)
+      _(ENV!.empty?).must_equal(false)
     end
 
     it "implements .except correctly" do
       if {}.respond_to?(:except)
-        ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
+        _(ENV!.except('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal({
           'ONE'      => 1,
           'A'        => 'A',
         })
       else
-        ENV!.respond_to?(:except).must_equal false
+        _(ENV!.respond_to?(:except)).must_equal false
       end
     end
 
     it "implements .fetch correctly" do
-      ENV!.fetch('ONE').must_equal 1
-      proc {
+      _(ENV!.fetch('ONE')).must_equal 1
+      _{
         ENV!.fetch('TWO')
       }.must_raise KeyError
-      ENV!.fetch('TWO', 2).must_equal 2
-      ENV!.fetch('TWO') { 22 }.must_equal 22
+      _(ENV!.fetch('TWO', 2)).must_equal 2
+      _(ENV!.fetch('TWO') { 22 }).must_equal 22
     end
 
     it "implements .invert correctly" do
-      ENV!.invert.must_equal({
+      _(ENV!.invert).must_equal({
         1 => 'ONE',
         'A' => 'A',
         { one: 1, two: 2 } => 'INT_HASH',
@@ -499,42 +499,42 @@ describe ENV_BANG do
     end
 
     it "implements .key correctly" do
-      ENV!.key(1).must_equal 'ONE'
+      _(ENV!.key(1)).must_equal 'ONE'
     end
 
     it "implements .key?/.has_key? correctly" do
-      ENV!.key?('ONE').must_equal true
-      ENV!.has_key?('ONE').must_equal true
+      _(ENV!.key?('ONE')).must_equal true
+      _(ENV!.has_key?('ONE')).must_equal true
 
-      ENV!.key?('TWO').must_equal false
-      ENV!.has_key?('TWO').must_equal false
+      _(ENV!.key?('TWO')).must_equal false
+      _(ENV!.has_key?('TWO')).must_equal false
     end
 
     it "implements .length correctly" do
-      ENV!.length.must_equal 4
-      ENV!.size.must_equal 4
+      _(ENV!.length).must_equal 4
+      _(ENV!.size).must_equal 4
     end
 
     it "implements .slice correctly" do
-      ENV!.slice('INT_HASH', 'FLOAT', 'NOTATHING').must_equal({
+      _(ENV!.slice('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal({
         'INT_HASH' => { one: 1, two: 2 },
         'FLOAT'    => 1.234,
       })
     end
 
     it "implements .to_hash correctly" do
-      ENV!.to_hash.must_equal ENV!.to_h
+      _(ENV!.to_hash).must_equal ENV!.to_h
     end
 
     it "implements .value?/has_value? correctly" do
-      ENV!.value?(1).must_equal true
-      ENV!.value?(2).must_equal false
-      ENV!.has_value?(1).must_equal true
-      ENV!.has_value?(2).must_equal false
+      _(ENV!.value?(1)).must_equal true
+      _(ENV!.value?(2)).must_equal false
+      _(ENV!.has_value?(1)).must_equal true
+      _(ENV!.has_value?(2)).must_equal false
     end
 
     it "implements .values_at correctly" do
-      ENV!.values_at('INT_HASH', 'FLOAT', 'NOTATHING').must_equal [
+      _(ENV!.values_at('INT_HASH', 'FLOAT', 'NOTATHING')).must_equal [
         { one: 1, two: 2 }, 1.234, nil
       ]
     end

--- a/test/env_bang_test.rb
+++ b/test/env_bang_test.rb
@@ -449,20 +449,20 @@ describe ENV_BANG do
 
     it "implements .each_pair correctly" do
       _(ENV!.each_pair.to_a).must_equal(ENV!.to_a)
-      keys = []
-      ENV!.each_pair do |key|
-        keys << key
+      pairs = []
+      ENV!.each_pair do |pair|
+        pairs << pair
       end
-      _(keys).must_equal(ENV!.to_a)
+      _(pairs).must_equal(ENV!.to_a)
     end
 
     it "implements .each_value correctly" do
       _(ENV!.each_value.to_a).must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
-      keys = []
-      ENV!.each_value do |key|
-        keys << key
+      values = []
+      ENV!.each_value do |value|
+        values << value
       end
-      _(keys).must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
+      _(values).must_equal [1, 'A', { one: 1, two: 2 }, 1.234]
     end
 
     it "implements .empty? correctly" do


### PR DESCRIPTION
Version 1.0 has a `missing_method` definition that delegates many methods directly to `ENV`. This includes methods like `[]=` (which writes to ENV) or `.to_h` (which surprisingly returns a hash of _all_ environment variables).

This change replaces the `missing_method` delegation with an explicit definition of all methods that we want to include in `ENV!`. This grows the code quite a bit, but it's not hard to cover the API thoroughly.